### PR TITLE
Force LF line endings when writing files

### DIFF
--- a/src/toml_fmt_common/__init__.py
+++ b/src/toml_fmt_common/__init__.py
@@ -264,7 +264,7 @@ def _handle_one(info: TOMLFormatter[T], config: _Config[T]) -> bool:
         return changed
 
     if before != formatted and not config.check:
-        config.toml_filename.write_text(formatted, encoding="utf-8")
+        config.toml_filename.write_text(formatted, encoding="utf-8", newline="\n")
     if config.no_print_diff:
         return changed
     try:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -279,3 +279,14 @@ def test_dumb_path_no_write(capsys: pytest.CaptureFixture[str], tmp_path: Path) 
     out, err = capsys.readouterr()
     assert "\ntoml-fmt-common: error: argument inputs: cannot write path\n" in err
     assert not out
+
+
+def test_writes_lf_line_endings(tmp_path: Path) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+
+    run(Dumb(), ["E", str(dumb)])
+
+    raw = dumb.read_bytes()
+    assert b"\r\n" not in raw
+    assert b"\n" in raw


### PR DESCRIPTION
Use `newline="\\n"` in `write_text()` to prevent Windows from converting LF to CRLF.

```python
# before
config.toml_filename.write_text(formatted, encoding="utf-8")

# after
config.toml_filename.write_text(formatted, encoding="utf-8", newline="\\n")
```

Fixes tox-dev/toml-fmt#99